### PR TITLE
validate node ids when fetching remote manifests

### DIFF
--- a/src/node/dht/dht.c
+++ b/src/node/dht/dht.c
@@ -146,7 +146,14 @@ bool valid_peer_host(node_ctx_t *ctx, char *peer_host) {
 bool valid_node_id(node_manifest_t *manifest) {
   char computed_node_id_string[512];
   node_id_from_public_key(manifest->public_key, computed_node_id_string);
-  return strcmp(computed_node_id_string, manifest->node_id) == 0;
+
+  bool valid = false;
+  
+  if (strcmp(computed_node_id_string, manifest->node_id) == 0) {
+    valid = true;
+  }
+
+  return valid;
 }
 
 /****

--- a/src/node/manifest/manifest.c
+++ b/src/node/manifest/manifest.c
@@ -13,6 +13,22 @@
 
 #include <stdlib.h>
 
+result_t node_id_from_public_key(char *public_key_string, char *node_id_output) {
+  char node_id_string[512];
+  result_t res_public_key_hash =
+      openssl_hash_data(public_key_string, strlen(public_key_string));
+  char *public_key_hash = PROPAGATE(res_public_key_hash);
+
+  strcpy(node_id_string, "SHOGN");
+  strcat(node_id_string, &public_key_hash[32]);
+
+  free(public_key_hash);
+
+  strcpy(node_id_output, node_id_string);
+  return OK(NULL);
+ }
+
+
 /****
  * creates a bew node manifest as a json string derived from the public key and
  * public host of the node
@@ -29,16 +45,10 @@ result_t generate_node_manifest(char *public_key_string, char *public_host,
   manifest.version = version;
 
   char node_id_string[512];
-  result_t res_public_key_hash =
-      openssl_hash_data(stripped_public_key, strlen(stripped_public_key));
-  char *public_key_hash = PROPAGATE(res_public_key_hash);
-
-  strcpy(node_id_string, "SHOGN");
-  strcat(node_id_string, &public_key_hash[32]);
+  result_t node_id_result = node_id_from_public_key(stripped_public_key, node_id_string);
+  PROPAGATE(node_id_result);
 
   manifest.node_id = node_id_string;
-
-  free(public_key_hash);
 
   result_t res_manifest_json = json_node_manifest_to_json(manifest);
   json_t *manifest_json = PROPAGATE(res_manifest_json);

--- a/src/node/manifest/manifest.h
+++ b/src/node/manifest/manifest.h
@@ -11,6 +11,8 @@
 #ifndef SHOG_NODE_MANIFEST_H
 #define SHOG_NODE_MANIFEST_H
 
+result_t node_id_from_public_key(char *public_key_string, char *node_id_output);
+
 result_t generate_node_manifest(char *public_key_path, char *public_host,
                                 bool has_explorer, char *version);
 


### PR DESCRIPTION
currently there is no validation which lets a malicious node assume the identity of a new node in the network, if they are able to submit their manifest before the victim node.

i was unable to write a test for this, looks like the netlibc changes broke the suite. validated it manually by removing `~/shoggoth/node/dump.rdb` and seeing that `shoggoth.systems`, `node1...` and `node2...` were successfully added into my local node.