### PR TITLE
Fix openssl not being found in tests

### DIFF
--- a/tests/client/makefile
+++ b/tests/client/makefile
@@ -12,7 +12,7 @@ LDFLAGS += -lasan -lubsan
 endif
 
 CFLAGS += -I ../../lib/netlibc/include
-LDFLAGS += -lssl -lcrypto $$(pkg-config --cflags --libs uuid)
+LDFLAGS += $$(pkg-config --cflags --libs uuid) $$(pkg-config --libs openssl)
 
 TARGET_DIR = ../../target
 

--- a/tests/node/makefile
+++ b/tests/node/makefile
@@ -12,7 +12,7 @@ LDFLAGS += -lasan -lubsan
 endif
 
 CFLAGS += -I ../../lib/netlibc/include
-LDFLAGS += -lssl -lcrypto $$(pkg-config --cflags --libs uuid)
+LDFLAGS += $$(pkg-config --cflags --libs uuid) $$(pkg-config --libs openssl)
 
 TARGET_DIR = ../../target
 


### PR DESCRIPTION
Like https://github.com/thenetrunna/shoggoth/pull/1 but for `make test`